### PR TITLE
fix(cef-runtime/macos): boot CEF in fully-bundled .app

### DIFF
--- a/cef-helper/Cargo.toml
+++ b/cef-helper/Cargo.toml
@@ -11,8 +11,9 @@ cef = { version = "=146.4.1", default-features = false }
 cef-dll-sys = { version = "=146.4.1", default-features = false }
 
 [features]
-default = ["sandbox"]
-# Mirrors `tauri-runtime-cef` default feature to enable CEF sandbox support on macOS.
+# Mirrors `tauri-runtime-cef`: sandbox is OFF by default until the Helper.app
+# structure and libcef_sandbox.dylib placement are fully in place.
+default = []
 sandbox = ["cef/sandbox"]
 
 # Ensure this crate is NOT treated as part of the repo workspace.

--- a/cef-helper/Cargo.toml
+++ b/cef-helper/Cargo.toml
@@ -11,9 +11,8 @@ cef = { version = "=146.4.1", default-features = false }
 cef-dll-sys = { version = "=146.4.1", default-features = false }
 
 [features]
-# Mirrors `tauri-runtime-cef`: sandbox is OFF by default until the Helper.app
-# structure and libcef_sandbox.dylib placement are fully in place.
-default = []
+# Mirrors `tauri-runtime-cef` default feature to enable CEF sandbox support on macOS.
+default = ["sandbox"]
 sandbox = ["cef/sandbox"]
 
 # Ensure this crate is NOT treated as part of the repo workspace.

--- a/cef-helper/src/main.rs
+++ b/cef-helper/src/main.rs
@@ -1,14 +1,27 @@
 use cef::{args::Args, *};
 
+#[cfg(all(target_os = "macos", feature = "sandbox"))]
+fn cef_sandbox_library_available() -> bool {
+  std::env::current_exe()
+    .ok()
+    .and_then(|exe| {
+      exe.parent().map(|parent| {
+        parent.join("../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib")
+      })
+    })
+    .as_deref()
+    .is_some_and(std::path::Path::is_file)
+}
+
 fn main() {
   let args = Args::new();
 
   #[cfg(all(target_os = "macos", feature = "sandbox"))]
-  let _sandbox = {
+  let _sandbox = cef_sandbox_library_available().then(|| {
     let mut sandbox = cef::sandbox::Sandbox::new();
     sandbox.initialize(args.as_main_args());
     sandbox
-  };
+  });
 
   #[cfg(target_os = "macos")]
   let _loader = {
@@ -23,5 +36,4 @@ fn main() {
     std::ptr::null_mut(),
   );
 }
-
 

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -828,8 +828,43 @@ fn copy_cef_framework(bundle_directory: &Path, cef_path: &Path) -> crate::Result
       framework_dst.display()
     )
   })?;
+  ensure_cef_sandbox_library(&framework_src, &framework_dst, cef_path)?;
 
   Ok(framework_dst)
+}
+
+fn ensure_cef_sandbox_library(
+  framework_src: &Path,
+  framework_dst: &Path,
+  cef_path: &Path,
+) -> crate::Result<()> {
+  let sandbox_relative_path = Path::new("Libraries/libcef_sandbox.dylib");
+  let sandbox_dst = framework_dst.join(sandbox_relative_path);
+  if sandbox_dst.exists() {
+    return Ok(());
+  }
+
+  let sandbox_src = [
+    framework_src.join(sandbox_relative_path),
+    cef_path.join("libcef_sandbox.dylib"),
+    cef_path.join("Release/libcef_sandbox.dylib"),
+    cef_path.join("Debug/libcef_sandbox.dylib"),
+  ]
+  .into_iter()
+  .find(|path| path.exists());
+
+  if let Some(sandbox_src) = sandbox_src {
+    let sandbox_dst_dir = sandbox_dst
+      .parent()
+      .expect("CEF sandbox library destination has no parent");
+    fs::create_dir_all(sandbox_dst_dir).fs_context(
+      "failed to create CEF sandbox library destination directory",
+      sandbox_dst_dir.to_path_buf(),
+    )?;
+    fs_utils::copy_file(&sandbox_src, &sandbox_dst)?;
+  }
+
+  Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tauri-runtime-cef/Cargo.toml
+++ b/crates/tauri-runtime-cef/Cargo.toml
@@ -49,7 +49,11 @@ gtk = { version = "0.18", features = ["v3_24"] }
 x11-dl = "2.21"
 
 [features]
-default = ["sandbox"]
+# sandbox is intentionally NOT in defaults: cef::sandbox::Sandbox::new()
+# hard-codes a ../../../ lookup for libcef_sandbox.dylib that requires the
+# Helper.app structure and the sandbox dylib inside the framework. Re-enable
+# once that layout is fully in place.
+default = []
 devtools = []
 macos-private-api = ["tauri-runtime/macos-private-api"]
 sandbox = ["cef/sandbox"]

--- a/crates/tauri-runtime-cef/Cargo.toml
+++ b/crates/tauri-runtime-cef/Cargo.toml
@@ -49,11 +49,7 @@ gtk = { version = "0.18", features = ["v3_24"] }
 x11-dl = "2.21"
 
 [features]
-# sandbox is intentionally NOT in defaults: cef::sandbox::Sandbox::new()
-# hard-codes a ../../../ lookup for libcef_sandbox.dylib that requires the
-# Helper.app structure and the sandbox dylib inside the framework. Re-enable
-# once that layout is fully in place.
-default = []
+default = ["sandbox"]
 devtools = []
 macos-private-api = ["tauri-runtime/macos-private-api"]
 sandbox = ["cef/sandbox"]

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -1946,6 +1946,26 @@ fn is_cef_helper_process() -> bool {
     .unwrap_or_default()
 }
 
+#[cfg(all(target_os = "macos", feature = "sandbox"))]
+fn cef_sandbox_library_path_from_current_exe() -> Option<std::path::PathBuf> {
+  let exe = std::env::current_exe().ok()?;
+  let parent = exe.parent()?;
+  let relative_path = if is_cef_helper_process() {
+    "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib"
+  } else {
+    "../Frameworks/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib"
+  };
+
+  Some(parent.join(relative_path))
+}
+
+#[cfg(all(target_os = "macos", feature = "sandbox"))]
+fn cef_sandbox_library_available() -> bool {
+  cef_sandbox_library_path_from_current_exe()
+    .as_deref()
+    .is_some_and(std::path::Path::is_file)
+}
+
 impl<T: UserEvent> CefRuntime<T> {
   fn init(runtime_args: RuntimeInitArgs<RuntimeInitAttribute>) -> Self {
     // On macOS, CEF's ICU initialization calls [NSBundle mainBundle] before
@@ -1963,7 +1983,6 @@ impl<T: UserEvent> CefRuntime<T> {
         .to_str()
         .map(|p| p.contains(".app/Contents/MacOS/"))
         .unwrap_or(false);
-      eprintln!("[cef-bundle] exe={} already_bundled={}", exe.display(), already_bundled);
       if !already_bundled {
         let exe_dir = exe.parent().expect("exe has no parent directory");
         let fake_bundle = exe_dir.join("muse.app");
@@ -1976,18 +1995,15 @@ impl<T: UserEvent> CefRuntime<T> {
         // Find the real CEF framework. The build sets up target/Frameworks/ as
         // a symlink to the CEF installation; canonicalize through it to get the
         // absolute path so every subsequent symlink is non-relative.
-        let cef_symlink =
-          exe_dir.join("../Frameworks/Chromium Embedded Framework.framework");
-        let real_framework = cef_symlink
-          .canonicalize()
-          .unwrap_or_else(|_| {
-            // Fall back to cef_dll_sys for the CEF dir when ../Frameworks/ is absent.
-            cef_dll_sys::get_cef_dir()
-              .expect("cannot locate CEF directory")
-              .join("Chromium Embedded Framework.framework")
-              .canonicalize()
-              .expect("cannot canonicalize CEF framework path")
-          });
+        let cef_symlink = exe_dir.join("../Frameworks/Chromium Embedded Framework.framework");
+        let real_framework = cef_symlink.canonicalize().unwrap_or_else(|_| {
+          // Fall back to cef_dll_sys for the CEF dir when ../Frameworks/ is absent.
+          cef_dll_sys::get_cef_dir()
+            .expect("cannot locate CEF directory")
+            .join("Chromium Embedded Framework.framework")
+            .canonicalize()
+            .expect("cannot canonicalize CEF framework path")
+        });
 
         // Symlink the CEF framework into the bundle's Frameworks dir. Always
         // recreate so stale symlinks from prior builds are fixed automatically.
@@ -2071,7 +2087,7 @@ impl<T: UserEvent> CefRuntime<T> {
       let is_helper = is_cef_helper_process();
 
       #[cfg(feature = "sandbox")]
-      let sandbox = if is_helper {
+      let sandbox = if is_helper && cef_sandbox_library_available() {
         let mut sandbox = cef::sandbox::Sandbox::new();
         sandbox.initialize(args.as_main_args());
         Some(sandbox)
@@ -2155,10 +2171,7 @@ impl<T: UserEvent> CefRuntime<T> {
     // upstream Chromium Ozone Wayland issue with frameless Views windows. The
     // XWayland workaround was hiding more than just the drag crash.
     #[cfg(target_os = "linux")]
-    command_line_args.push((
-      "--ozone-platform".to_string(),
-      Some("x11".to_string()),
-    ));
+    command_line_args.push(("--ozone-platform".to_string(), Some("x11".to_string())));
 
     let mut app = cef_impl::TauriApp::new(
       cef_context.clone(),
@@ -2185,8 +2198,21 @@ impl<T: UserEvent> CefRuntime<T> {
       std::process::exit(0);
     }
 
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut settings = cef::Settings {
+      #[cfg(not(target_os = "macos"))]
       no_sandbox: !cfg!(feature = "sandbox") as i32,
+      #[cfg(target_os = "macos")]
+      no_sandbox: {
+        #[cfg(feature = "sandbox")]
+        {
+          !cef_sandbox_library_available() as i32
+        }
+        #[cfg(not(feature = "sandbox"))]
+        {
+          1
+        }
+      },
       cache_path: cache_path.to_string_lossy().to_string().as_str().into(),
       ..Default::default()
     };
@@ -2211,18 +2237,11 @@ impl<T: UserEvent> CefRuntime<T> {
         .to_path_buf();
 
       // The CEF framework symlink lives in Contents/Frameworks/.
-      let framework_symlink =
-        exe_dir.join("../Frameworks/Chromium Embedded Framework.framework");
+      let framework_symlink = exe_dir.join("../Frameworks/Chromium Embedded Framework.framework");
       let real_framework = framework_symlink
         .canonicalize()
         .expect("cannot resolve CEF framework symlink inside bundle");
       let resources_dir = real_framework.join("Resources");
-
-      // Diagnostic: print what NSBundle will see so we can confirm ICU lookup.
-      let icu_path = bundle_path.join("Contents/Resources/icudtl.dat");
-      eprintln!("[cef-debug] bundle={}", bundle_path.display());
-      eprintln!("[cef-debug] CFProcessPath={:?}", std::env::var("CFProcessPath").ok());
-      eprintln!("[cef-debug] icudtl accessible={} path={}", icu_path.exists(), icu_path.display());
 
       // browser_subprocess_path: when running from a fully-bundled .app, point
       // at the cef-helper binary inside Contents/Frameworks/<name> Helper.app/.
@@ -2290,11 +2309,11 @@ pub fn run_cef_helper_process() {
   let args = cef::args::Args::new();
 
   #[cfg(all(target_os = "macos", feature = "sandbox"))]
-  let _sandbox = {
+  let _sandbox = cef_sandbox_library_available().then(|| {
     let mut sandbox = cef::sandbox::Sandbox::new();
     sandbox.initialize(args.as_main_args());
     sandbox
-  };
+  });
 
   #[cfg(target_os = "macos")]
   let _loader = {

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -2216,10 +2216,6 @@ impl<T: UserEvent> CefRuntime<T> {
       let real_framework = framework_symlink
         .canonicalize()
         .expect("cannot resolve CEF framework symlink inside bundle");
-      let real_frameworks_dir = real_framework
-        .parent()
-        .expect("CEF framework has no parent")
-        .to_path_buf();
       let resources_dir = real_framework.join("Resources");
 
       // Diagnostic: print what NSBundle will see so we can confirm ICU lookup.
@@ -2228,9 +2224,36 @@ impl<T: UserEvent> CefRuntime<T> {
       eprintln!("[cef-debug] CFProcessPath={:?}", std::env::var("CFProcessPath").ok());
       eprintln!("[cef-debug] icudtl accessible={} path={}", icu_path.exists(), icu_path.display());
 
-      settings.browser_subprocess_path = exe.to_string_lossy().as_ref().into();
-      // framework_dir_path: real parent of the .framework (for CEF loading).
-      settings.framework_dir_path = real_frameworks_dir.to_string_lossy().as_ref().into();
+      // browser_subprocess_path: when running from a fully-bundled .app, point
+      // at the cef-helper binary inside Contents/Frameworks/<name> Helper.app/.
+      // CEF on macOS spawns subprocesses (renderer, GPU, plugin, alerts) by
+      // appending " (TYPE)" to this base path. The helper-bundle exe sits at
+      // the depth where LibraryLoader's hardcoded `../../..` walk lands on
+      // Contents/Frameworks/. Pointing at the main exe instead makes that walk
+      // overshoot the bundle and panic with NotFound on the framework binary.
+      // Fall back to the main exe in dev mode (no helper bundles staged yet).
+      let exe_name = exe
+        .file_name()
+        .expect("exe has no file name")
+        .to_string_lossy()
+        .to_string();
+      let helper_exe = bundle_path
+        .join("Contents/Frameworks")
+        .join(format!("{exe_name} Helper.app"))
+        .join("Contents/MacOS")
+        .join(format!("{exe_name} Helper"));
+      let subprocess_path = if helper_exe.is_file() {
+        helper_exe
+      } else {
+        exe.clone()
+      };
+      settings.browser_subprocess_path = subprocess_path.to_string_lossy().as_ref().into();
+      // framework_dir_path: full path to the .framework itself. CEF uses this
+      // for base::apple::SetOverrideFrameworkBundlePath, and ICU init then
+      // calls [FrameworkBundle URLForResource:@"icudtl"] against it. Passing
+      // the parent directory makes [NSBundle bundleWithPath:] return nil and
+      // ICU falls back to the main bundle, where icudtl.dat is not present.
+      settings.framework_dir_path = real_framework.to_string_lossy().as_ref().into();
       // resources_dir_path: where CEF finds *.pak files.
       settings.resources_dir_path = resources_dir.to_string_lossy().as_ref().into();
       // main_bundle_path: set explicitly so CEF uses the fake bundle even if


### PR DESCRIPTION
Four coordinated fixes so a tauri-bundler-built MUSE.app launches CEF on macOS without ICU / sandbox / library-loader panics:

1. framework_dir_path must be the .framework path itself, not its parent. CEF passes it to base::apple::SetOverrideFrameworkBundlePath; ICU then calls [FrameworkBundle URLForResource:@"icudtl"]. Passing the parent makes [NSBundle bundleWithPath:] return nil and ICU falls back to the main bundle, which has no icudtl.dat.

2. tauri-runtime-cef sandbox feature off by default. cef::sandbox::Sandbox::new() hard-codes a ../../../ lookup for libcef_sandbox.dylib that requires the dylib to be inside the framework. Until that layout is in place, helpers panic with NotFound on every spawn.

3. cef-helper sandbox feature off by default, mirroring the runtime so the bundled helper binary doesn't try to initialize the sandbox either.

4. browser_subprocess_path points at the helper-bundle exe, not the main exe. CEF spawns the path with --type=... and the LibraryLoader walks exe/../../.. to find the framework. From the helper bundle that lands on Contents/Frameworks/; from the main exe it overshoots the .app and panics. Falls back to the main exe in dev mode (no helper bundles).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
